### PR TITLE
Remove datatype context from 'DecimalRaw'.

### DIFF
--- a/src/Decimal/src/Data/Decimal.hs
+++ b/src/Decimal/src/Data/Decimal.hs
@@ -64,7 +64,7 @@ import Text.ParserCombinators.ReadP
 -- using @Integer@ types, so application developers do not need to worry about
 -- overflow in the internal algorithms.  However the result of each operator
 -- will be converted to the mantissa type without checking for overflow.
-data (Integral i) => DecimalRaw i = Decimal {
+data DecimalRaw i = Decimal {
       decimalPlaces :: ! Word8,
       decimalMantissa :: ! i}
                                   deriving (Typeable)
@@ -78,7 +78,7 @@ data (Integral i) => DecimalRaw i = Decimal {
 -- to and from @Integer@.
 type Decimal = DecimalRaw Integer
 
-instance (Integral i, NFData i) => NFData (DecimalRaw i) where
+instance (NFData i) => NFData (DecimalRaw i) where
     rnf (Decimal _ i) = rnf i
     
 instance (Integral i) => Enum (DecimalRaw i) where


### PR DESCRIPTION
@PaulJohnson, this patch removes the datatype context (the `Integral i` constraint) from the definition of `DecimalRaw i`. I also removed the constraint from the definition of the `NFData` instance.

There are several reasons to do this. First, the context doesn't do anything; the library behaves the same without it. Second, datatype contexts were removed from the Haskell 2011 standard and are now broadly considered a bad idea. Third, the context prevents doing some useful things with `DecimalRaw` and `Decimal`, e.g., using `GHC.Generics` to derive instances automatically.
