### PR TITLE
Compatibility with GHC-9.0

### DIFF
--- a/src/Data/Decimal.hs
+++ b/src/Data/Decimal.hs
@@ -66,8 +66,8 @@ import Text.ParserCombinators.ReadP
 -- will return \"1.500\".  Conversely the "Read" instance will use the decimal
 -- places to determine the precision.
 data DecimalRaw i = Decimal {
-      decimalPlaces :: ! Word8,
-      decimalMantissa :: ! i}
+      decimalPlaces :: !Word8,
+      decimalMantissa :: !i}
                                   deriving (Typeable)
 
 


### PR DESCRIPTION
Starting with `ghc-9.0`, there are new whitepspacing rules around "bang patterns" (`!`) to remove ambiguity in niche situations with infix operators/constructors.

Currently `Decimal` does not build with the `ghc-9.0` release candidate because there is whitespace in the strict data constructor:

```
Configuring library for Decimal-0.5.1..
Preprocessing library for Decimal-0.5.1..
Building library for Decimal-0.5.1..
[1 of 1] Compiling Data.Decimal     ( src/Data/Decimal.hs, dist/build/Data/Decimal.o, dist/build/Data/Decimal.dyn_o )

src/Data/Decimal.hs:69:24: error:
    Operator applied to too few arguments: !
   |
69 |       decimalPlaces :: ! Word8,
   |                        ^
cabal: Failed to build Decimal-0.5.1
```

This pull request fixes the compilation error, making `Decimal` compatible with `ghc-9.0`.