### PR TITLE
Add Data.Data.Data instance for Decimal(Raw)

### DIFF
--- a/src/Data/Decimal.hs
+++ b/src/Data/Decimal.hs
@@ -50,10 +50,10 @@ module Data.Decimal (
 
 
 import Control.DeepSeq
+import Data.Data
 import Data.Char
 import Data.Ratio
 import Data.Word
-import Data.Typeable
 import Text.ParserCombinators.ReadP
 
 -- | Raw decimal arithmetic type constructor.  A decimal value consists of an
@@ -68,7 +68,7 @@ import Text.ParserCombinators.ReadP
 data DecimalRaw i = Decimal {
       decimalPlaces :: !Word8,
       decimalMantissa :: !i}
-                                  deriving (Typeable)
+                                  deriving (Data, Typeable)
 
 
 -- | Arbitrary precision decimal type.  Programs should do decimal


### PR DESCRIPTION
This relates to #24.

As a particular use case for `Data`, it's (recursively) used by [Control.Lens.Plated](https://hackage.haskell.org/package/lens-5.2.3/docs/Control-Lens-Plated.html) to autoderive the `Plated` instance, hence if any type contains a `Decimal` (perhaps transitively), right now it cannot be auto`Plated`, which is unfortunate and boilerplatey.